### PR TITLE
Update DLO-138.ino

### DIFF
--- a/DLO-138.ino
+++ b/DLO-138.ino
@@ -1,5 +1,9 @@
 #include <EEPROM.h>
-#include <Adafruit_GFX.h>
+
+#include <Adafruit_GFX.h> 
+// needs to be Adafruit GFX Library v1.1.4, check/change your installed version
+// otherwise you will get a black screen or compiler errors
+
 #include "src/TFTLib/Adafruit_TFTLCD_8bit_STM32.h"
 #include "global.h"
 #include "variables.h"


### PR DESCRIPTION
small comment in the main .ino file to remind people which version of the Adafruit GFX Lib to use.